### PR TITLE
fix: Bybit OHLCV取得修正 & 1年分データ取得完了

### DIFF
--- a/scripts/fetch_ohlcv.py
+++ b/scripts/fetch_ohlcv.py
@@ -3,7 +3,7 @@
 
 Usage:
     python scripts/fetch_ohlcv.py --exchange binance --symbol BTC/USDT:USDT --start 2025-03-01 --end 2026-03-01
-    python scripts/fetch_ohlcv.py --exchange bybit --symbol ETH/USDT:USDT --timeframe 1h
+    python scripts/fetch_ohlcv.py --exchange bybit --symbol ETH/USDT:USDT --timeframe 1h --start 2025-03-01
 """
 
 import argparse
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import ccxt
 import pandas as pd
+import requests
 
 logging.basicConfig(
     level=logging.INFO,
@@ -22,6 +23,18 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+BYBIT_INTERVAL_MAP = {
+    "1m": "1", "3m": "3", "5m": "5", "15m": "15", "30m": "30",
+    "1h": "60", "2h": "120", "4h": "240", "6h": "360", "12h": "720",
+    "1d": "D", "1w": "W", "1M": "M",
+}
+
+INTERVAL_MS = {
+    "1m": 60_000, "3m": 180_000, "5m": 300_000, "15m": 900_000, "30m": 1_800_000,
+    "1h": 3_600_000, "2h": 7_200_000, "4h": 14_400_000, "6h": 21_600_000,
+    "12h": 43_200_000, "1d": 86_400_000, "1w": 604_800_000,
+}
 
 
 def parse_args():
@@ -57,6 +70,7 @@ def fetch_all_ohlcv(
     end_ms: int,
     limit: int = 1000,
 ) -> list:
+    """Fetch OHLCV using ccxt (works well for Binance)."""
     all_data = []
     current_since = since_ms
 
@@ -77,7 +91,7 @@ def fetch_all_ohlcv(
             logger.info("No more data returned, stopping.")
             break
 
-        # Filter out data beyond end_ms
+        ohlcv.sort(key=lambda x: x[0])
         ohlcv = [row for row in ohlcv if row[0] < end_ms]
         if not ohlcv:
             break
@@ -88,12 +102,84 @@ def fetch_all_ohlcv(
             f"Fetched {len(ohlcv)} candles, last: {datetime.fromtimestamp(last_ts/1000, tz=timezone.utc).isoformat()}"
         )
 
-        # Move past the last candle
         current_since = last_ts + 1
 
         if len(ohlcv) < limit:
             break
 
+    return all_data
+
+
+def fetch_bybit_ohlcv_rest(
+    symbol_raw: str,
+    timeframe: str,
+    since_ms: int,
+    end_ms: int,
+) -> list:
+    """Fetch OHLCV directly from Bybit v5 REST API (handles descending order)."""
+    pair = symbol_raw.split(":")[0].replace("/", "")
+    interval = BYBIT_INTERVAL_MAP.get(timeframe, "60")
+    interval_ms = INTERVAL_MS.get(timeframe, 3_600_000)
+    url = "https://api.bybit.com/v5/market/kline"
+    all_data = []
+    limit = 1000
+
+    # Bybit returns data newest-first, so we iterate with end sliding backward
+    current_end = end_ms
+
+    while current_end > since_ms:
+        params = {
+            "category": "linear",
+            "symbol": pair,
+            "interval": interval,
+            "start": since_ms,
+            "end": current_end,
+            "limit": limit,
+        }
+
+        try:
+            resp = requests.get(url, params=params, timeout=30)
+            resp.raise_for_status()
+            result = resp.json()
+        except Exception as e:
+            logger.warning(f"Request error, retrying in 5s: {e}")
+            time.sleep(5)
+            continue
+
+        if result.get("retCode") != 0:
+            logger.error(f"Bybit API error: {result.get('retMsg')}")
+            break
+
+        items = result.get("result", {}).get("list", [])
+        if not items:
+            break
+
+        # Convert to standard format [timestamp, open, high, low, close, volume]
+        batch = []
+        for item in items:
+            ts = int(item[0])
+            if since_ms <= ts < end_ms:
+                batch.append([ts, float(item[1]), float(item[2]), float(item[3]), float(item[4]), float(item[5])])
+
+        batch.sort(key=lambda x: x[0])
+        if not batch:
+            break
+
+        all_data.extend(batch)
+        oldest_ts = batch[0][0]
+        logger.info(
+            f"Fetched {len(batch)} candles, oldest: {datetime.fromtimestamp(oldest_ts/1000, tz=timezone.utc).isoformat()}"
+        )
+
+        # Move end back to just before the oldest item
+        current_end = oldest_ts - 1
+
+        if len(items) < limit:
+            break
+
+        time.sleep(0.2)
+
+    all_data.sort(key=lambda x: x[0])
     return all_data
 
 
@@ -107,7 +193,6 @@ def to_dataframe(data: list) -> pd.DataFrame:
 def output_path(exchange_id: str, symbol: str, timeframe: str, custom_path: str = None) -> Path:
     if custom_path:
         return Path(custom_path)
-    # BTC/USDT:USDT -> btcusdt
     clean_symbol = symbol.split(":")[0].replace("/", "").lower()
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     return DATA_DIR / f"{exchange_id}_{clean_symbol}_{timeframe}.parquet"
@@ -116,13 +201,16 @@ def output_path(exchange_id: str, symbol: str, timeframe: str, custom_path: str 
 def main():
     args = parse_args()
 
-    exchange = create_exchange(args.exchange)
     since_ms = to_ms(args.start)
     end_ms = to_ms(args.end) if args.end else int(datetime.now(timezone.utc).timestamp() * 1000)
 
     logger.info(f"Fetching {args.symbol} {args.timeframe} from {args.exchange} ({args.start} to {args.end or 'now'})")
 
-    data = fetch_all_ohlcv(exchange, args.symbol, args.timeframe, since_ms, end_ms)
+    if args.exchange == "bybit":
+        data = fetch_bybit_ohlcv_rest(args.symbol, args.timeframe, since_ms, end_ms)
+    else:
+        exchange = create_exchange(args.exchange)
+        data = fetch_all_ohlcv(exchange, args.symbol, args.timeframe, since_ms, end_ms)
 
     if not data:
         logger.warning("No data fetched.")


### PR DESCRIPTION
## Summary

- Bybit v5 REST APIを直接使用してOHLCVの降順レスポンス問題を解決
- 4ペア全て8,760レコード（1年分）の取得を確認

Closes #2

## Test plan

- [x] `pytest tests/test_fetch_ohlcv.py` 18テスト全パス
- [x] Binance BTC/ETH: 各8,760レコード確認
- [x] Bybit BTC/ETH: 各8,760レコード確認
- [x] 日付範囲: 2025-03-01 00:00 ~ 2026-02-28 23:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)