### PR TITLE
fix: sui-auto-lp 安定性改修

### DIFF
--- a/systems/sui-auto-lp/src/core/rebalance.ts
+++ b/systems/sui-auto-lp/src/core/rebalance.ts
@@ -228,6 +228,25 @@ export async function deployIdleFunds(
       }
     }
 
+    // Zero balance defense: RPC may return stale 0 balances after swap/close
+    if (deployA === 0n && deployB === 0n) {
+      log.info('Idle deploy: both balances are zero, re-querying after RPC settle', { iteration })
+      await new Promise(r => setTimeout(r, 3000))
+      const retryWallet = await getWalletBalances(owner, pool.coinTypeA, pool.coinTypeB)
+      deployA = retryWallet.balanceA
+      deployB = retryWallet.balanceB > GAS_RESERVE ? retryWallet.balanceB - GAS_RESERVE : 0n
+
+      if (deployA === 0n && deployB === 0n) {
+        log.info('Idle deploy: balances still zero after re-query, skipping iteration', { iteration })
+        continue
+      }
+      log.info('Idle deploy: balances recovered after re-query', {
+        iteration,
+        deployA_USDC: (Number(deployA) / 1e6).toFixed(4),
+        deployB_SUI: (Number(deployB) / 1e9).toFixed(4),
+      })
+    }
+
     let result = await addLiquidity(
       pool.poolId,
       positionId,
@@ -837,8 +856,49 @@ export async function checkAndRebalance(
   )
 
   if (!finalOpenResult.success) {
+    // --- RPC delay retry: re-query balances and retry once (all triggers) ---
+    if (finalOpenResult.error?.includes('Insufficient balance')) {
+      log.info('Open failed with Insufficient balance — retrying after RPC settle', {
+        error: finalOpenResult.error,
+      })
+      await new Promise(r => setTimeout(r, 3000))
+
+      const retryWallet = await getWalletBalances(owner, pool.coinTypeA, pool.coinTypeB)
+      if (position.liquidity === 0n) {
+        finalBalanceA = retryWallet.balanceA
+        const rawB = retryWallet.balanceB
+        finalBalanceB = rawB > GAS_RESERVE ? rawB - GAS_RESERVE : 0n
+      } else {
+        const deltaA = retryWallet.balanceA - preClose.balanceA
+        const deltaB = retryWallet.balanceB - preClose.balanceB
+        finalBalanceA = deltaA > 0n ? deltaA : 0n
+        const rawB = deltaB > 0n ? deltaB : 0n
+        finalBalanceB = rawB > GAS_RESERVE ? rawB - GAS_RESERVE : 0n
+      }
+
+      log.info('RPC retry: re-queried balances', {
+        amountA_USDC: (Number(finalBalanceA) / 1e6).toFixed(4),
+        amountB_SUI: (Number(finalBalanceB) / 1e9).toFixed(4),
+      })
+
+      finalOpenResult = await openPosition(
+        pool.poolId,
+        pool.coinTypeA,
+        pool.coinTypeB,
+        newRange.tickLower,
+        newRange.tickUpper,
+        finalBalanceA.toString(),
+        finalBalanceB.toString(),
+        config.slippageTolerance,
+        keypair,
+        config.dryRun,
+        pool.rewarderCoinTypes,
+        pool.currentSqrtPrice,
+      )
+    }
+
     // --- Swap fallback for range-out trigger in swap-free mode ---
-    if (swapFree && decision.trigger === 'range-out') {
+    if (!finalOpenResult.success && swapFree && decision.trigger === 'range-out') {
       log.warn('Swap-free open failed on range-out, falling back to swap', {
         error: finalOpenResult.error,
       })
@@ -940,7 +1000,10 @@ export async function checkAndRebalance(
       // Success via fallback
       swapFree = false
       finalOpenResult = retryResult
-    } else {
+    }
+
+    // Final failure — all retries exhausted
+    if (!finalOpenResult.success) {
       log.error('CRITICAL: Position closed + swapped but failed to open new one!', {
         poolId: pool.poolId,
         error: finalOpenResult.error,

--- a/systems/sui-auto-lp/src/strategy/trigger.ts
+++ b/systems/sui-auto-lp/src/strategy/trigger.ts
@@ -106,7 +106,7 @@ function estimateBreakevenHoursFallback(
   rangeWidthPct: number,
   dailyVolumeRatio?: number,
 ): number {
-  const volumeRatio = dailyVolumeRatio ?? 0.02
+  const volumeRatio = dailyVolumeRatio ?? 0.035
   const capitalEfficiency = 1 / (2 * rangeWidthPct)
   const swapCostPct = poolFeeRate * 0.5
   const dailyFeeRatePct = poolFeeRate * volumeRatio * capitalEfficiency
@@ -250,7 +250,7 @@ export function validateProfitabilityGateConfig(
       tickWidthMin,
       alignedMin,
       poolFeeRate,
-      dailyVolumeRatio: dailyVolumeRatio ?? 0.02,
+      dailyVolumeRatio: dailyVolumeRatio ?? 0.035,
       rangeWidthPct: rangeWidthPct.toFixed(4),
       breakevenHours: breakevenHours.toFixed(1),
       maxBreakevenHours,

--- a/systems/sui-auto-lp/test/unit/trigger.test.ts
+++ b/systems/sui-auto-lp/test/unit/trigger.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../src/utils/logger.js', () => ({
   }),
 }))
 
-import { evaluateRebalanceTrigger, recordRebalanceForDay } from '../../src/strategy/trigger.js'
+import { evaluateRebalanceTrigger, recordRebalanceForDay, validateProfitabilityGateConfig } from '../../src/strategy/trigger.js'
 import { getCurrentPrice, tickToPrice } from '../../src/core/price.js'
 
 const mockedGetCurrentPrice = vi.mocked(getCurrentPrice)
@@ -1063,6 +1063,53 @@ describe('evaluateRebalanceTrigger', () => {
 
       expect(result.shouldRebalance).toBe(true)
       expect(result.trigger).toBe('range-out')
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // 16. validateProfitabilityGateConfig
+  // ------------------------------------------------------------------
+  describe('validateProfitabilityGateConfig', () => {
+    it('should pass with updated default volumeRatio (0.035) for volTickWidthMin=480 + 0.25% fee', () => {
+      const result = validateProfitabilityGateConfig(
+        0.0025,  // poolFeeRate (0.25%)
+        480,     // tickWidthMin
+        60,      // tickSpacing
+        48,      // maxBreakevenHours
+        // no dailyVolumeRatio → uses new default 0.035
+      )
+      expect(result.ok).toBe(true)
+      expect(result.breakevenHours).toBeLessThan(48)
+    })
+
+    it('should fail with old default volumeRatio (0.02) for volTickWidthMin=480 + 0.25% fee', () => {
+      const result = validateProfitabilityGateConfig(
+        0.0025,
+        480,
+        60,
+        48,
+        0.02,  // explicitly use old default
+      )
+      expect(result.ok).toBe(false)
+      expect(result.breakevenHours).toBeGreaterThan(48)
+    })
+
+    it('should calculate correct breakeven hours for known inputs', () => {
+      // volumeRatio=0.035, rangeWidthPct = 480 * 0.0001 = 0.048
+      // capitalEfficiency = 1 / (2 * 0.048) = 10.42
+      // swapCostPct = 0.0025 * 0.5 = 0.00125
+      // dailyFeeRatePct = 0.0025 * 0.035 * 10.42 = 0.000912
+      // hourlyFeeRatePct = 0.000912 / 24 = 0.000038
+      // breakeven = 0.00125 / 0.000038 = ~32.9h
+      const result = validateProfitabilityGateConfig(0.0025, 480, 60, 48)
+      expect(result.breakevenHours).toBeCloseTo(32.9, 0)
+    })
+
+    it('should return ok=false for very wide ranges (low capital efficiency)', () => {
+      // Wider range = lower capital efficiency = harder to break even
+      const result = validateProfitabilityGateConfig(0.0025, 1200, 60)
+      expect(result.ok).toBe(false)
+      expect(result.breakevenHours).toBeGreaterThan(48)
     })
   })
 


### PR DESCRIPTION
## Summary
- **Config conflict解消**: `FALLBACK_DAILY_VOLUME_RATIO` デフォルトを `0.02`→`0.035` に変更。実測ハーベストデータ（$59/day on ~$3K position）から逆算し、fallback breakeven を 57.6h→32.9h に低下させ起動時warningを解消
- **Open失敗リトライ**: `Insufficient balance` エラー時に3秒待機+balance再取得→リトライ（1回）を全trigger共通で追加。既存のswap fallback（range-out限定）の前段に挿入
- **ゼロバランス防御**: `deployIdleFunds` の `addLiquidity` 前にゼロバランスチェック追加。RPC遅延で `balanceA=0, balanceB=0` の場合に3秒待機+再取得、それでもゼロならイテレーションスキップ
- **テスト追加**: `validateProfitabilityGateConfig` のテスト4件（新デフォルト値pass、旧値regression、計算精度、wide range動作）

## Test plan
- [x] `npm run type-check` — 型チェック通過
- [x] `npm test` — 全272テスト通過（新規4テスト含む）
- [ ] `DRY_RUN=true npm run dev` — 起動時config conflict warningが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)